### PR TITLE
Add thangs to app name

### DIFF
--- a/thangs_login.py
+++ b/thangs_login.py
@@ -47,7 +47,7 @@ class ThangsLogin(threading.Thread):
     def authenticate(self):
         codeChallengeId = uuid.uuid4()
 
-        webbrowser.open(f"{self.config['url']}profile/client-access-grant?verifierCode={codeChallengeId}&version=blender-addon&appName=blender+addon")
+        webbrowser.open(f"{self.config['url']}profile/client-access-grant?verifierCode={codeChallengeId}&version=blender-addon&appName=Thangs+blender+add+on")
 
         return codeChallengeId
 


### PR DESCRIPTION
# What?

This value can be used to identify the app in the thangs client authorization route, to make this look better I change `blender+addon` to `Thangs+blender+add+on`.

