### PR TITLE
Some fixes and cleanup for text search

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -935,6 +935,7 @@ def unregister():
     addon_updater_ops.unregister()
 
     stop_access_grant()
+    urllib.request.urlcleanup()
 
 
 if __name__ == "__main__":

--- a/__init__.py
+++ b/__init__.py
@@ -388,7 +388,7 @@ class ThangsLink(bpy.types.Operator):
     def execute(self, context):
         amplitude.send_amplitude_event("nav to thangs", event_properties={})
         webbrowser.open(thangs_config.thangs_config["url"] + "search/" +fetcher.query +
-                        "?utm_source=blender&utm_medium=referral&utm_campaign=blender_extender&fileTypes=stl%2Cgltf%2Cobj%2Cfbx%2Cglb%2Csldprt%2Cstep%2Cmtl%2Cdxf%2Cstp&scope=thangs", new=0, autoraise=True)
+                        "?utm_source=blender&utm_medium=referral&utm_campaign=blender_extender", new=0, autoraise=True)
         return {'FINISHED'}
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -387,7 +387,7 @@ class ThangsLink(bpy.types.Operator):
 
     def execute(self, context):
         amplitude.send_amplitude_event("nav to thangs", event_properties={})
-        webbrowser.open("https://thangs.com/search/"+fetcher.query +
+        webbrowser.open(thangs_config.thangs_config["url"] + "search/" +fetcher.query +
                         "?utm_source=blender&utm_medium=referral&utm_campaign=blender_extender&fileTypes=stl%2Cgltf%2Cobj%2Cfbx%2Cglb%2Csldprt%2Cstep%2Cmtl%2Cdxf%2Cstp&scope=thangs", new=0, autoraise=True)
         return {'FINISHED'}
 

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -365,13 +365,13 @@ class ThangsFetcher():
 
         if self.newSearch == True:
             response = requests.get(self.Thangs_Config.thangs_config['url']+"api/models/v2/search-by-text?page="+str(self.CurrentPage-1)+"&searchTerm="+self.query +
-                                    "&pageSize=8&narrow=false&collapse=true&fileTypes=stl%2Cgltf%2Cobj%2Cfbx%2Cglb%2Csldprt%2Cstep%2Cmtl%2Cdxf%2Cstp&scope=thangs",
+                                    "&pageSize=8&narrow=false&collapse=true",
                                     headers={"x-fp-val": self.FP.getVal(self.Thangs_Config.thangs_config['url']+"fp_m")})
         else:
             response = requests.get(
                 str(self.Thangs_Config.thangs_config['url'])+"api/models/v2/search-by-text?page=" +
                 str(self.CurrentPage-1)+"&searchTerm="+self.query +
-                "&pageSize=8&narrow=false&collapse=true&fileTypes=stl%2Cgltf%2Cobj%2Cfbx%2Cglb%2Csldprt%2Cstep%2Cmtl%2Cdxf%2Cstp&scope=thangs",
+                "&pageSize=8&narrow=false&collapse=true",
                 headers={"x-thangs-searchmetadata": base64.b64encode(
                     json.dumps(self.searchMetaData).encode()).decode(),
                     "x-fp-val": self.FP.getVal(self.Thangs_Config.thangs_config['url']+"fp_m")},

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -365,13 +365,13 @@ class ThangsFetcher():
 
         if self.newSearch == True:
             response = requests.get(self.Thangs_Config.thangs_config['url']+"api/models/v2/search-by-text?page="+str(self.CurrentPage-1)+"&searchTerm="+self.query +
-                                    "&pageSize=8&narrow=false&collapse=true",
+                                    "&pageSize=8&collapse=true",
                                     headers={"x-fp-val": self.FP.getVal(self.Thangs_Config.thangs_config['url']+"fp_m")})
         else:
             response = requests.get(
                 str(self.Thangs_Config.thangs_config['url'])+"api/models/v2/search-by-text?page=" +
                 str(self.CurrentPage-1)+"&searchTerm="+self.query +
-                "&pageSize=8&narrow=false&collapse=true",
+                "&pageSize=8&collapse=true",
                 headers={"x-thangs-searchmetadata": base64.b64encode(
                     json.dumps(self.searchMetaData).encode()).decode(),
                     "x-fp-val": self.FP.getVal(self.Thangs_Config.thangs_config['url']+"fp_m")},

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -287,6 +287,8 @@ class ThangsFetcher():
 
     def get_http_search(self):
         global thangs_config
+        # Clean up temporary files from previous attempts
+        urllib.request.urlcleanup()
         print("Started Search")
         self.searching = True
 

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -21,6 +21,7 @@ from .thangs_events import ThangsEvents
 from .config import get_config, ThangsConfig
 from .thangs_importer import ThangsApi, initialize_thangs_api, get_thangs_api, Utils, Config
 import bpy
+import ssl
 import socket
 from bpy.types import WindowManager
 import bpy.utils.previews
@@ -401,15 +402,17 @@ class ThangsFetcher():
             self.i = 0
             #self.enumModelTotal.append(("NONE", "None", "", 1))
 
+            # ugh
+            old_context = ssl._create_default_https_context
+            ssl._create_default_https_context = ssl._create_unverified_context
+
             for item in items:
                 self.enumModelInfo.clear()
 
                 if len(item["thumbnails"]) > 0:
                     thumbnail = item["thumbnails"][0]
                 else:
-                    thumbnailAPIURL = item["thumbnailUrl"]
-                    thumbnailURL = requests.head(thumbnailAPIURL)
-                    thumbnail = thumbnailURL.headers["Location"]
+                    thumbnail = item["thumbnailUrl"]
 
                 modelTitle = item["modelTitle"]
                 modelId = item["modelId"]
@@ -420,8 +423,7 @@ class ThangsFetcher():
                 self.enumItems.append(
                     (modelTitle, modelId, item["ownerUsername"], item["license"]))#, item["originalFileType"]))
 
-                thumbnail = thumbnail.replace("https", "http", 1)
-
+                print(f'Fetching {thumbnail}')
                 filePath = urllib.request.urlretrieve(thumbnail)
 
                 filepath = os.path.join(modelId, filePath[0])
@@ -490,14 +492,8 @@ class ThangsFetcher():
                     for part in parts:
                         ModelTitle = part["modelFileName"]
                         modelID = part["modelId"]
-                        thumbnailAPIURL = part["thumbnailUrl"]
-                        try:
-                            thumbnailURL = requests.head(
-                                thumbnailAPIURL, timeout=5)
-                        except Timeout:
-                            continue
-                        thumbnail = thumbnailURL.headers["Location"]
-                        thumbnail = thumbnail.replace("https", "http", 1)
+                        thumbnail = part["thumbnailUrl"]
+                        print(f'Fetching part {thumbnail}')
                         filePath = urllib.request.urlretrieve(thumbnail)
                         filepath = os.path.join(modelID, filePath[0])
                         thumb = self.pcoll.load(modelID, filepath, 'IMAGE')
@@ -542,6 +538,7 @@ class ThangsFetcher():
                 self.enumModelTotal.append(self.enumModelInfo[:])
                 self.i = self.i + 1
 
+        ssl._create_default_https_context = old_context
         if self.enumModels1:
             self.length.append(len(self.enumModels1))
             self.result1 = self.enumModels1[0][3]

--- a/thangs_login.py
+++ b/thangs_login.py
@@ -52,7 +52,7 @@ class ThangsLogin(threading.Thread):
     def authenticate(self):
         codeChallengeId = uuid.uuid4()
 
-        webbrowser.open(f"{self.config['url']}profile/client-access-grant?verifierCode={codeChallengeId}&version=blender-addon&appName=Thangs+blender+add+on")
+        webbrowser.open(f"{self.config['url']}profile/client-access-grant?verifierCode={codeChallengeId}&version=blender-addon&appName=Thangs+Blender+addon")
 
         return codeChallengeId
 


### PR DESCRIPTION
Cleans up some items related to Thangs text search and fixes a couple bugs:

* Removes the `filetypes` filter from searches.  We don't need to filter by the file types that blender supports, as even if blender doesn't support it directly we can convert on the Thangs side of things
* Use the configured thangs url for "Open in Thangs"
* Remove the thangs-only search scope.  Search all of the models that we index on thangs
* Remove an unused query param (`narrow`)
* Fix thumbnail fetching.  Fetch the thumbnails directly, with a bit of hackiness re: SSL cert verification
* Clean up the application name that we show when logging the user in
* Clean up any temporary files from fetching thumbnails