### PR TITLE
Fix circular import between importer and login

### DIFF
--- a/thangs_login.py
+++ b/thangs_login.py
@@ -1,6 +1,5 @@
 from time import sleep 
 from .config import get_config, ThangsConfig
-from .thangs_importer import ThangsApi
 import uuid, webbrowser, requests, threading
 
 GRANT_CHECK_INTERVAL_SECONDS=0.5 # 500 milliseconds


### PR DESCRIPTION
Noticed that the code in the development branch failed to run because of a circular import