### PR TITLE
Cleanup Thangs Breeze installs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 bl_info = {
     "name": "Thangs Model Search",
     "author": "Thangs",
-    "version": (0, 2, 0),
+    "version": (0, 2, 1),
     "blender": (3, 2, 0),
     "location": "VIEW 3D > Tools > Thangs Search",
     "description": "Browse and download free 3D models",


### PR DESCRIPTION
If you manually install this addon while the old "thangs breeze" addon was already installed, you'll end up with duplicates of the thangs addon, one under `thangs-blender-addon` and another under `thangs-breeze`.

This release adds a bit that cleans up an old `thangs-breeze` install if it finds one.