### PR TITLE
Changes for asset gen grouping.

### DIFF
--- a/services/thangs_sync_service.py
+++ b/services/thangs_sync_service.py
@@ -186,9 +186,17 @@ class ThangsSyncService:
                                                                                     model_id)
                 sha = version_response['sha']
             else:
-                model_ids = sync_client.create_model_from_current_blend_file(token, filename, upload_urls[0]['newFileName'],
-                                                                             [r['newFileName'] for r in image_upload_urls],
-                                                                             bpy.context.scene.thangs_blender_addon_sync_panel_sync_as_public_model)
+                asset_group_id = sync_client.create_asset_group(token, upload_urls[0]['newFileName'], [
+                                                                r['newFileName'] for r in image_upload_urls])
+
+                sync_client.poll_asset_group(
+                    token, asset_group_id['assetGroupId'])
+
+                model_ids = sync_client.create_model_from_current_blend_file_with_asset_group(token, filename, upload_urls[0]['newFileName'],
+                                                                                              [r['newFileName'] for r in image_upload_urls],
+                                                                                              bpy.context.scene.thangs_blender_addon_sync_panel_sync_as_public_model,
+                                                                                              asset_group_id['assetGroupId'])
+
                 model_id = model_ids[0]
 
             current_step = 5


### PR DESCRIPTION
These are the changes to support asset generation grouping for the blender add on. More info https://github.com/physna/thangs-product-dev/issues/1723

Right now the polling plan for `v2/models/assetGroup/:id` is set to poll every 2 seconds and then after 10 attempts which is 20 seconds of polling back off to 5 second polling and do that for 10 minutes. This can be easily adjusted and I think will be OK compared to sync because we're not submitting collections of more than 1 blend model via the blender add on.

Test plan:
There are a set of models that we commonly use that I uploaded to Google Drive which is [here](https://drive.google.com/file/d/1kTUqbZsQH454RGS-4K6YZnrt6zeSReKE/view?usp=share_link). Below are my findings from that list. Specifically I was trying to test models that have external textures but I also tested some that do not.
- [x] anime_girl
- [x] dominos
- [x] low_poly_assets
- [x] no_game
- [x] snow_bushes
- [x] stones_low_poly
- [x] airship - not in the zip
- [x] primo corazon - not in the zip
- [x] tracery - not in the zip
- [x] Various STL's, OBJ's, and GLB's imported from thangs search.
- [x] Tested private and public on/off 
- [x] Tested sync on save 
- [ ] Pyramids - This file is erroring on upload. I found out the issue existed before. Created an issue [here for it](https://github.com/physna/thangs-product-dev/issues/1993).