### PR TITLE
Reject blend back up files.

### DIFF
--- a/services/thangs_sync_service.py
+++ b/services/thangs_sync_service.py
@@ -86,7 +86,7 @@ class ThangsSyncService:
             split_tup_top = os.path.splitext(filename)
             file_extension = split_tup_top[1]
             if file_extension != '.blend':
-                self.__set_ui_status_message(f'Upload error occured. This is a blender backup file with extension [{file_extension}]. Please open a .blend file.')
+                self.__set_ui_status_message(f'Upload error occurred. This is a blender backup file with extension [{file_extension}]. Please open a .blend file.')
                 self.__reset_sync_process()
                 return
 

--- a/services/thangs_sync_service.py
+++ b/services/thangs_sync_service.py
@@ -83,6 +83,13 @@ class ThangsSyncService:
                     return
 
             filename = bpy.path.basename(bpy.context.blend_data.filepath)
+            split_tup_top = os.path.splitext(filename)
+            file_extension = split_tup_top[1]
+            if file_extension != '.blend':
+                self.__set_ui_status_message(f'Upload error occured. This is a blender backup file with extension [{file_extension}]. Please open a .blend file.')
+                self.__reset_sync_process()
+                return
+
             sync_client = ThangsFileSyncClient()
 
             is_saved_as_public_model: bool = None


### PR DESCRIPTION
We received one .blend1 file in our db which was ingested through the blender-addon. Blender generates back up files incrementing the file extension by 1 with each save for example, .blend1, .blend2, etc.  We added validation to reject these and asking the user to open a valid .blend file.