### PR TITLE
Added saving a UUID and a thumbnail refactor.

### DIFF
--- a/api_clients/thangs_events.py
+++ b/api_clients/thangs_events.py
@@ -6,6 +6,7 @@ import platform
 import uuid
 import json
 import os
+import bpy
 
 from config import get_config
 
@@ -16,7 +17,8 @@ class ThangsEvents(object):
         self.__Thangs_Config = get_config()
         self.__ampURL = self.__Thangs_Config.thangs_config['event_url']
         self.__addon_version = self.__Thangs_Config.version
-        self.__deviceId = socket.gethostname().split(".")[0]
+        self.__cached_deviceId = None
+        self.__deviceId = self.get_deviceId()
         self.__deviceOs = platform.system()
         self.__deviceVer = platform.release()
         pass
@@ -75,8 +77,71 @@ class ThangsEvents(object):
         except Exception as e:
             print(e)
 
+    def get_deviceId(self):
+        try:
+            if self.__cached_deviceId != None:
+                return self.__cached_deviceId
+            
+            user_config_path = bpy.utils.resource_path('USER')
+            device_id_json_file_location = os.path.join(os.path.dirname(user_config_path), 'thangs-blender-addon-id.json')
+
+            if os.path.exists(device_id_json_file_location):
+                deviceId_file = open(device_id_json_file_location)
+                data = json.load(deviceId_file)
+                self.__cached_deviceId = data["deviceId"]
+                return self.__cached_deviceId
+            else:
+                folder_above_user_config = os.path.basename(os.path.dirname(user_config_path))
+                
+                if folder_above_user_config.casefold() == 'blender':
+                    self.__cached_deviceId = str(uuid.uuid4())
+                    deviceId = {
+                        'deviceId': self.__cached_deviceId,
+                    }
+                    with open(device_id_json_file_location, 'w') as json_file:
+                        json.dump(deviceId, json_file)
+                    return self.__cached_deviceId
+                else:
+                    error = "Could not find blender folder in this path:" + user_config_path
+                    send_amp_event_on_initialization_error(error)
+                    self.__cached_deviceId = socket.gethostname().split(".")[0]
+                    return self.__cached_deviceId
+        except Exception as e:
+            print(e)
+            send_amp_event_on_initialization_error(e)
+            self.__cached_deviceId = socket.gethostname().split(".")[0]
+            return self.__cached_deviceId
+
 __thangs_events__: ThangsEvents = None
 
+def _send_amp_event_on_initialization_error(error):
+    event_name = "Thangs Blender Addon - DeviceId Initialization Failed"
+    event = {
+        'event_type': event_name,
+        'device_id': socket.gethostname().split(".")[0],
+        'event_properties': {
+            'addon_version': str(get_config().version),
+            'device_os': str(platform.system()),
+            'device_ver': str(platform.release()),
+            'source': "blender",
+            'exception': str(error),
+        }
+    }
+
+    try:
+        response = requests.post(get_config().thangs_config['event_url'], json={'events': [event]})
+        log.info('Sent amplitude event: ' + event_name + 'Response: ' + str(response.status_code) + " " +
+                    response.headers['x-cloud-trace-context'])
+    except Exception as e:
+        print(e)
+
+def send_amp_event_on_initialization_error(error):
+    threading.Thread(
+        target=_send_amp_event_on_initialization_error,
+        args=(error,)
+    ).start()
+    return
+    
 def get_thangs_events():
     global __thangs_events__
 

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -361,7 +361,6 @@ class ThangsFetcher():
 
             try:
                 thumb = self.pcoll.load(item["modelId"], image_path, 'IMAGE')
-                raise Exception
             except Exception as e:
                 self.amplitude.send_amplitude_event("Thangs Blender Addon - Thumbnail Error",
                                                     event_properties={

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -348,6 +348,7 @@ class ThangsFetcher():
                 print(e)
                 filePath = os.path.join(os.path.dirname(self.Thangs_Config.main_addon_file_location),"icons","placeholder.png")
                 image_path = os.path.join(item["modelId"], filePath)
+                self.cached_model_images[item["modelId"]] = image_path
                 self.amplitude.send_amplitude_event("Thangs Blender Addon - Thumbnail Error",
                                     event_properties={
                                         'exception': str(e),

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -314,8 +314,6 @@ class ThangsFetcher():
             else:
                 thumbnail = item["thumbnailUrl"]
 
-            #thumbnail = f"https://thangs-thumbs-dot-gcp-and-physna.uc.r.appspot.com/convert/{model_id}.stl?source=phyndexer-production-headless-bucket"
-
             download_path = None
             if item.get("arLink", None) != None:
                 download_path = item.get("arLink", None).get("path", None)
@@ -389,7 +387,7 @@ class ThangsFetcher():
 
             title = item.get('modelTitle') or item.get('modelFileName')
             self.modelList.append(self.ModelStruct(
-                modelTitle=title, partList=self.partList[:]))
+                modelTitle=title.strip(), partList=self.partList[:]))
 
             I += 1
 

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -338,7 +338,6 @@ class ThangsFetcher():
                 os.makedirs(model_images_folder)
 
             try:
-                print("self.Thangs_Config.main_addon_file_location",self.Thangs_Config.main_addon_file_location)
                 cached_image_path = self.cached_model_images.get(item.get("modelId", None), None)
                 if cached_image_path != None and os.path.exists(cached_image_path):
                     image_path = cached_image_path


### PR DESCRIPTION
Items in this release:
- [[Bug] : Certain searches on first install don't show thumbnails](https://github.com/physna/thangs-product-dev/issues/3240)
   - We refactored the thumbnail code a bit to save the paths for the downloaded thumbnail images. Previously, we were parsing the URL to get the path which was unreliable. Also, some amplitude events were added for errors.
- [[Bug] : Use a UUID instead of ID current being used in Blender for amp events](https://github.com/physna/thangs-product-dev/issues/3199)
    - For the UUID work, we are now saving a UUID json file in a parent `Blender` folder called by the same name. The path looks like this: `C:\Users\username\AppData\Roaming\Blender Foundation\Blender\3.6`. All versions of Blender share this `Blender` folder. We are putting the file here so that we have a consistent ID across all versions of Blender that the user has installed. If we can't find this `Blender` folder then we fall back to the originally calculated deviceID from the OS. If the user uninstalls the addon  or Blender and reinstalls it, we'll have the same UUID. Only if the user deletes the new json file will we create a new one for that user.

