### PR TITLE
Fixes for wrapping up the log in thread, adding the userid for amp events, updating the search string to v3, small thumbnail change.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -40,6 +40,9 @@ import time
 from config import get_config, initialize
 initialize(bl_info["version"], __file__)
 
+from login_token_cache import initialize
+initialize(__file__)
+
 from . import addon_updater_ops
 from urllib.request import urlopen
 from .thangs_fetcher import ThangsFetcher

--- a/__init__.py
+++ b/__init__.py
@@ -1024,8 +1024,7 @@ def register():
     bpy.app.timers.register(execute_queued_functions)
     bpy.app.timers.register(uninstall_old_version_timer)
 
-    global threading_service
-    threading_service = get_threading_service()
+    get_threading_service()
 
     log.info("Finished Register")
 

--- a/__init__.py
+++ b/__init__.py
@@ -40,8 +40,8 @@ import time
 from config import get_config, initialize
 initialize(bl_info["version"], __file__)
 
-from login_token_cache import initialize
-initialize(__file__)
+from login_token_cache import initialize_token
+initialize_token(__file__)
 
 from . import addon_updater_ops
 from urllib.request import urlopen

--- a/__init__.py
+++ b/__init__.py
@@ -47,7 +47,7 @@ from api_clients import get_thangs_events
 from .thangs_importer import initialize_thangs_api, get_thangs_api
 from UI.common import View3DPanel
 from UI.sync import register as sync_register, unregister as sync_unregister
-from services import get_sync_service
+from services import get_sync_service, get_threading_service
 
 log = logging.getLogger(__name__)
 
@@ -1024,6 +1024,9 @@ def register():
     bpy.app.timers.register(execute_queued_functions)
     bpy.app.timers.register(uninstall_old_version_timer)
 
+    global threading_service
+    threading_service = get_threading_service()
+
     log.info("Finished Register")
 
 
@@ -1070,6 +1073,9 @@ def unregister():
     addon_updater_ops.unregister()
 
     urllib.request.urlcleanup()
+
+    threading_service = get_threading_service()
+    threading_service.wrap_up_threads_now()
 
     sync_service = get_sync_service()
     sync_service.cancel_running_sync_process()

--- a/api_clients/thangs_events.py
+++ b/api_clients/thangs_events.py
@@ -8,7 +8,7 @@ import json
 import os
 import bpy
 
-from config import get_config
+from config import get_config, get_api_token
 
 log = logging.getLogger(__name__)
 
@@ -71,7 +71,10 @@ class ThangsEvents(object):
     def _send_amplitude_event(self, event_name, event_properties):
         event = self._construct_event(event_name, event_properties)
         try:
-            response = requests.post(self.__ampURL, json={'events': [event]})
+            if get_api_token() == None:
+                response = requests.post(self.__ampURL, json={'events': [event]})
+            else:
+                response = requests.post(self.__ampURL, json={'events': [event]}, headers={'Authorization': "Bearer "+get_api_token()})
             log.info('Sent amplitude event: ' + event_name + 'Response: ' + str(response.status_code) + " " +
                      response.headers['x-cloud-trace-context'])
         except Exception as e:

--- a/api_clients/thangs_events.py
+++ b/api_clients/thangs_events.py
@@ -8,7 +8,8 @@ import json
 import os
 import bpy
 
-from config import get_config, get_api_token
+from config import get_config
+from login_token_cache import get_api_token
 
 log = logging.getLogger(__name__)
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,1 +1,1 @@
-from .config import get_config, initialize, set_token, get_bearer_json_file_location, get_api_token
+from .config import get_config, initialize

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,1 +1,1 @@
-from .config import get_config, initialize
+from .config import get_config, initialize, set_token, get_bearer_json_file_location, get_api_token

--- a/config/config.py
+++ b/config/config.py
@@ -1,8 +1,6 @@
 import logging
 import configparser
 import os
-import json
-from typing import Optional
 
 log = logging.getLogger(__name__)
 _thangs_config = None
@@ -18,46 +16,6 @@ def initialize(version, main_addon_file_location: str):
     _thangs_config = ThangsConfig(version, main_addon_file_location)
 
 
-def set_token(token):
-    global _thangs_config
-    _thangs_config.cached_token = token
-
-
-def get_bearer_json_file_location(main_addon_file_location = None) -> str:
-    global _thangs_config
-    if main_addon_file_location == None:
-        file_location = _thangs_config.main_addon_file_location
-    else:
-        file_location = main_addon_file_location
-    bearer_location = os.path.join(os.path.dirname(file_location), 'bearer.json')
-    return bearer_location
-
-def get_api_token() -> Optional[str]:
-    global _thangs_config
-    if _thangs_config.cached_token:
-        return _thangs_config.cached_token
-
-    bearer_location = get_bearer_json_file_location()
-    if not os.path.exists(bearer_location):
-        set_token(None)
-        return _thangs_config.cached_token
-    bearer_file = open(bearer_location)
-    data = json.load(bearer_file)
-    set_token(data["bearer"])
-    return _thangs_config.cached_token
-
-
-def initialize_api_token(main_addon_file_location = None):
-    global _thangs_config
-
-    bearer_location = get_bearer_json_file_location(main_addon_file_location)
-    if not os.path.exists(bearer_location):
-        return None
-    bearer_file = open(bearer_location)
-    data = json.load(bearer_file)
-    return data["bearer"]
-
-
 class ThangsConfig(object):
     def __init__(self, version, main_addon_file_location: str):
         """ Don't call this to get the config.  Use get_config(). """
@@ -68,5 +26,4 @@ class ThangsConfig(object):
         self.config_obj.read(self.config_path)
         self.thangs_config = self.config_obj['thangs']
         self.version = str(version)
-        self.cached_token = initialize_api_token(main_addon_file_location)
     pass

--- a/config/config.py
+++ b/config/config.py
@@ -1,6 +1,8 @@
 import logging
 import configparser
 import os
+import json
+from typing import Optional
 
 log = logging.getLogger(__name__)
 _thangs_config = None
@@ -16,6 +18,46 @@ def initialize(version, main_addon_file_location: str):
     _thangs_config = ThangsConfig(version, main_addon_file_location)
 
 
+def set_token(token):
+    global _thangs_config
+    _thangs_config.cached_token = token
+
+
+def get_bearer_json_file_location(main_addon_file_location = None) -> str:
+    global _thangs_config
+    if main_addon_file_location == None:
+        file_location = _thangs_config.main_addon_file_location
+    else:
+        file_location = main_addon_file_location
+    bearer_location = os.path.join(os.path.dirname(file_location), 'bearer.json')
+    return bearer_location
+
+def get_api_token() -> Optional[str]:
+    global _thangs_config
+    if _thangs_config.cached_token:
+        return _thangs_config.cached_token
+
+    bearer_location = get_bearer_json_file_location()
+    if not os.path.exists(bearer_location):
+        set_token(None)
+        return _thangs_config.cached_token
+    bearer_file = open(bearer_location)
+    data = json.load(bearer_file)
+    set_token(data["bearer"])
+    return _thangs_config.cached_token
+
+
+def initialize_api_token(main_addon_file_location = None):
+    global _thangs_config
+
+    bearer_location = get_bearer_json_file_location(main_addon_file_location)
+    if not os.path.exists(bearer_location):
+        return None
+    bearer_file = open(bearer_location)
+    data = json.load(bearer_file)
+    return data["bearer"]
+
+
 class ThangsConfig(object):
     def __init__(self, version, main_addon_file_location: str):
         """ Don't call this to get the config.  Use get_config(). """
@@ -26,4 +68,5 @@ class ThangsConfig(object):
         self.config_obj.read(self.config_path)
         self.thangs_config = self.config_obj['thangs']
         self.version = str(version)
+        self.cached_token = initialize_api_token(main_addon_file_location)
     pass

--- a/login_token_cache/__init__.py
+++ b/login_token_cache/__init__.py
@@ -1,0 +1,1 @@
+from .login_token_cache import initialize, set_token, get_bearer_json_file_location, get_api_token

--- a/login_token_cache/__init__.py
+++ b/login_token_cache/__init__.py
@@ -1,1 +1,1 @@
-from .login_token_cache import initialize, set_token, get_bearer_json_file_location, get_api_token
+from .login_token_cache import initialize_token, set_token, get_bearer_json_file_location, get_api_token

--- a/login_token_cache/login_token_cache.py
+++ b/login_token_cache/login_token_cache.py
@@ -8,7 +8,7 @@ from config import get_config
 log = logging.getLogger(__name__)
 _login_token_cache = None
 
-def initialize(main_addon_file_location: str):
+def initialize_token(main_addon_file_location: str):
     global _login_token_cache
     _login_token_cache = LoginTokenCache(main_addon_file_location)
 

--- a/login_token_cache/login_token_cache.py
+++ b/login_token_cache/login_token_cache.py
@@ -1,0 +1,55 @@
+import logging
+import os
+import json
+from typing import Optional
+from config import get_config
+
+
+log = logging.getLogger(__name__)
+_login_token_cache = None
+
+def initialize(main_addon_file_location: str):
+    global _login_token_cache
+    _login_token_cache = LoginTokenCache(main_addon_file_location)
+
+def set_token(token):
+    global _login_token_cache
+    _login_token_cache.cached_token = token
+
+def get_bearer_json_file_location(main_addon_file_location = None) -> str:
+    global _login_token_cache
+    if main_addon_file_location == None:
+        file_location = get_config().main_addon_file_location
+    else:
+        file_location = main_addon_file_location
+    bearer_location = os.path.join(os.path.dirname(file_location), 'bearer.json')
+    return bearer_location
+
+def get_api_token() -> Optional[str]:
+    global _login_token_cache
+    if _login_token_cache.cached_token:
+        return _login_token_cache.cached_token
+
+    bearer_location = get_bearer_json_file_location()
+    if not os.path.exists(bearer_location):
+        set_token(None)
+        return _login_token_cache.cached_token
+    bearer_file = open(bearer_location)
+    data = json.load(bearer_file)
+    set_token(data["bearer"])
+    return _login_token_cache.cached_token
+
+def initialize_api_token(main_addon_file_location = None):
+    global _login_token_cache
+
+    bearer_location = get_bearer_json_file_location(main_addon_file_location)
+    if not os.path.exists(bearer_location):
+        return None
+    bearer_file = open(bearer_location)
+    data = json.load(bearer_file)
+    return data["bearer"]
+
+class LoginTokenCache(object):
+    def __init__(self, main_addon_file_location: str):
+        self.cached_token = initialize_api_token(main_addon_file_location)
+    pass

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,3 +1,4 @@
 from .thangs_login_service import ThangsLoginService
 from .thangs_sync_service import SyncInfo, get_sync_service, enable_sync_on_save, supress_sync_on_save, sync_on_save_handler, reset_status_message_load_handler
 from .thumbnail_service import get_thumbnail_service
+from .threading_service import ThreadingService, get_threading_service

--- a/services/thangs_login_service.py
+++ b/services/thangs_login_service.py
@@ -46,6 +46,9 @@ class ThangsLoginService:
                 if e.response.status_code == 401:
                     print("Unsuccessful Login, 401 returned")
                     return
+                if e.response.status_code == 403:
+                    print("Login Denied, 403 returned")
+                    return
                 raise
 
         print("Unsuccessful Login, max attempts exceeded")

--- a/services/thangs_login_service.py
+++ b/services/thangs_login_service.py
@@ -3,48 +3,32 @@ import uuid
 import json
 import webbrowser
 import requests
-import threading
 
-from config import get_config
+from config import set_token, get_bearer_json_file_location, get_api_token
 from api_clients import thangs_login_client
 from time import sleep
 from typing import Optional
-
+from .threading_service import get_threading_service
 
 class ThangsLoginService:
     __GRANT_CHECK_INTERVAL_SECONDS = 0.5  # 500 milliseconds
     __MAX_ATTEMPTS = 600  # 5 minutes worth
 
     def __init__(self):
-        self.__cached_token = None
         self.__login_client = thangs_login_client.ThangsLoginClient()
 
-    def __get_bearer_json_file_location(self) -> str:
-        bearer_location = os.path.join(
-            os.path.dirname(get_config().main_addon_file_location), 'bearer.json')
-        return bearer_location
-
-    def get_api_token(self) -> Optional[str]:
-        if self.__cached_token:
-            return self.__cached_token
-
-        bearer_location = self.__get_bearer_json_file_location()
-        if not os.path.exists(bearer_location):
-            return None
-        bearer_file = open(bearer_location)
-        data = json.load(bearer_file)
-        return data["bearer"]
-
-    def login_user(self, cancellation_event: threading.Event = None) -> None:
-        if self.__cached_token:
-            self.__cached_token = None
+    def login_user(self) -> None:
+        if get_api_token:
+            set_token(None)
 
         challenge_id = uuid.uuid4()
         webbrowser.open(self.__login_client.get_browser_authenticate_url(challenge_id))
 
         attempts = 0
 
-        while attempts < ThangsLoginService.__MAX_ATTEMPTS and not (cancellation_event and cancellation_event.is_set()):
+        threading_service = get_threading_service()
+
+        while attempts < ThangsLoginService.__MAX_ATTEMPTS and not threading_service.wrap_up_threads:
             try:
                 sleep(self.__GRANT_CHECK_INTERVAL_SECONDS)
                 response = self.__login_client.check_access_grant(challenge_id, attempts)
@@ -57,9 +41,9 @@ class ThangsLoginService:
                 bearer = {
                     'bearer': bearer_token,
                 }
-                with open(self.__get_bearer_json_file_location(), 'w') as json_file:
+                with open(get_bearer_json_file_location(), 'w') as json_file:
                     json.dump(bearer, json_file)
-                self.__cached_token = response['TOKEN']
+                set_token(response['TOKEN'])
 
                 return
             except requests.HTTPError as e:

--- a/services/thangs_login_service.py
+++ b/services/thangs_login_service.py
@@ -4,9 +4,9 @@ import json
 import webbrowser
 import requests
 
-from config import set_token, get_bearer_json_file_location, get_api_token
 from api_clients import thangs_login_client
 from time import sleep
+from login_token_cache import set_token, get_bearer_json_file_location, get_api_token
 
 class ThangsLoginService:
     __GRANT_CHECK_INTERVAL_SECONDS = 0.5  # 500 milliseconds

--- a/services/thangs_login_service.py
+++ b/services/thangs_login_service.py
@@ -46,9 +46,6 @@ class ThangsLoginService:
                 if e.response.status_code == 401:
                     print("Unsuccessful Login, 401 returned")
                     return
-                if e.response.status_code == 403:
-                    print("Login Denied, 403 returned")
-                    return
                 raise
 
         print("Unsuccessful Login, max attempts exceeded")

--- a/services/thangs_sync_service.py
+++ b/services/thangs_sync_service.py
@@ -240,7 +240,7 @@ class ThangsSyncService:
                 self.__sync_current_blender_file()
             elif e.response.status_code == 403:
                 self.remove_sync_info_text_block()
-                self.__sync_current_blender_file()
+                self.__clear_ui_status_message()
             else:
                 self.__events_client.send_amplitude_event("Thangs Blender Addon - sync failed", event_properties={
                     'model_id': model_id,

--- a/services/thangs_sync_service.py
+++ b/services/thangs_sync_service.py
@@ -48,7 +48,6 @@ class ThangsSyncService:
 
     def cancel_running_sync_process(self):
         if self.__sync_thread:
-            print('cancel_running_sync_process')
             self.__sync_thread_stop_event.set()
             self.__sync_thread.join()
             self.__reset_sync_process()

--- a/services/thangs_sync_service.py
+++ b/services/thangs_sync_service.py
@@ -15,6 +15,7 @@ from .thangs_login_service import ThangsLoginService
 from api_clients import ThangsFileSyncClient, UploadUrlResponse, ThangsModelsClient, get_thangs_events
 # TODO I hate putting this in here, need to figure out how to separate the UI updates from the sync process
 from UI.common import redraw_areas
+from config import get_api_token
 
 
 class SyncInfo(TypedDict):
@@ -47,6 +48,7 @@ class ThangsSyncService:
 
     def cancel_running_sync_process(self):
         if self.__sync_thread:
+            print('cancel_running_sync_process')
             self.__sync_thread_stop_event.set()
             self.__sync_thread.join()
             self.__reset_sync_process()
@@ -75,10 +77,10 @@ class ThangsSyncService:
 
             self.__update_ui_current_step(current_step, total_steps)
 
-            token = self.__login_service.get_api_token()
+            token = get_api_token()
             if not token:
                 self.__login_service.login_user()
-                token = self.__login_service.get_api_token()
+                token = get_api_token()
                 if not token:
                     return
 

--- a/services/thangs_sync_service.py
+++ b/services/thangs_sync_service.py
@@ -15,7 +15,7 @@ from .thangs_login_service import ThangsLoginService
 from api_clients import ThangsFileSyncClient, UploadUrlResponse, ThangsModelsClient, get_thangs_events
 # TODO I hate putting this in here, need to figure out how to separate the UI updates from the sync process
 from UI.common import redraw_areas
-from config import get_api_token
+from login_token_cache import get_api_token
 from .threading_service import get_threading_service
 
 

--- a/services/thangs_sync_service.py
+++ b/services/thangs_sync_service.py
@@ -16,6 +16,7 @@ from api_clients import ThangsFileSyncClient, UploadUrlResponse, ThangsModelsCli
 # TODO I hate putting this in here, need to figure out how to separate the UI updates from the sync process
 from UI.common import redraw_areas
 from config import get_api_token
+from .threading_service import get_threading_service
 
 
 class SyncInfo(TypedDict):
@@ -78,7 +79,7 @@ class ThangsSyncService:
 
             token = get_api_token()
             if not token:
-                self.__login_service.login_user()
+                self.__login_service.login_user(get_threading_service().wrap_up_threads)
                 token = get_api_token()
                 if not token:
                     return
@@ -235,7 +236,7 @@ class ThangsSyncService:
         except requests.HTTPError as e:
             print(str(e))
             if e.response.status_code == 401:
-                self.__login_service.login_user()
+                self.__login_service.login_user(get_threading_service().wrap_up_threads)
                 self.__sync_current_blender_file()
             elif e.response.status_code == 403:
                 self.remove_sync_info_text_block()

--- a/services/threading_service.py
+++ b/services/threading_service.py
@@ -1,0 +1,18 @@
+class ThreadingService():
+
+    def __init__(self):
+        self.wrap_up_threads = False
+
+    def wrap_up_threads_now(self):
+        self.wrap_up_threads = True
+
+__threading_service__: ThreadingService = ThreadingService()
+
+def get_threading_service():
+    global __threading_service__
+
+    if not __threading_service__:
+        __threading_service__ = ThreadingService()
+    return __threading_service__
+
+

--- a/services/threading_service.py
+++ b/services/threading_service.py
@@ -1,10 +1,12 @@
+import threading
+
 class ThreadingService():
 
     def __init__(self):
-        self.wrap_up_threads = False
+        self.wrap_up_threads = threading.Event()
 
     def wrap_up_threads_now(self):
-        self.wrap_up_threads = True
+        self.wrap_up_threads.set()
 
 __threading_service__: ThreadingService = ThreadingService()
 
@@ -14,5 +16,3 @@ def get_threading_service():
     if not __threading_service__:
         __threading_service__ = ThreadingService()
     return __threading_service__
-
-

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -13,10 +13,12 @@ import time
 
 from .model_info import ModelInfo
 from api_clients import get_thangs_events
-from config import get_config, get_api_token
+from config import get_config
 from .thangs_importer import get_thangs_api, Utils, Config
 from pathlib import Path
 from services import ThangsLoginService, get_threading_service
+from login_token_cache import get_api_token
+
 
 
 class ThangsFetcher():

--- a/thangs_fetcher.py
+++ b/thangs_fetcher.py
@@ -16,7 +16,7 @@ from api_clients import get_thangs_events
 from config import get_config, get_api_token
 from .thangs_importer import get_thangs_api, Utils, Config
 from pathlib import Path
-from services import ThangsLoginService
+from services import ThangsLoginService, get_threading_service
 
 
 class ThangsFetcher():
@@ -671,7 +671,7 @@ class ThangsFetcher():
             self.pcoll = self.preview_collections["main"]
 
             if not get_api_token():
-                self.login_service.login_user()
+                self.login_service.login_user(get_threading_service().wrap_up_threads)
             headers = {
                 "Authorization": "Bearer " + get_api_token(),
             }
@@ -686,7 +686,7 @@ class ThangsFetcher():
             except Exception as e:
                 if response.status_code == 401 or response.status_code == 403:
                     try:
-                        self.login_service.login_user()
+                        self.login_service.login_user(get_threading_service().wrap_up_threads)
                         headers = {"Authorization": "Bearer " + get_api_token(), }
                         response = requests.get(url_endpoint, headers=headers)
                         response.raise_for_status()
@@ -759,7 +759,7 @@ class ThangsFetcher():
                 if response:
                     if response.status_code == 401 or response.status_code == 403:
                         try:
-                            self.login_service.login_user()
+                            self.login_service.login_user(get_threading_service().wrap_up_threads)
                             headers = {"Authorization": "Bearer " + get_api_token(), }
                             response = requests.get(url=url, headers=headers)
                             response.raise_for_status()

--- a/thangs_importer.py
+++ b/thangs_importer.py
@@ -7,10 +7,12 @@ import webbrowser
 import queue
 import time
 
-from config import get_config, get_api_token
+from config import get_config
 from api_clients import get_thangs_events
 from .model_importer import import_model
 from services import ThangsLoginService, get_threading_service
+from login_token_cache import get_api_token
+
 
 _thangs_api = None
 

--- a/thangs_importer.py
+++ b/thangs_importer.py
@@ -7,7 +7,7 @@ import webbrowser
 import queue
 import time
 
-from config import get_config
+from config import get_config, get_api_token
 from api_clients import get_thangs_events
 from .model_importer import import_model
 from services import ThangsLoginService
@@ -151,9 +151,9 @@ class ThangsApi:
                 break
 
         if not fileExists:
-            if not self.login_service.get_api_token():
+            if not get_api_token():
                 self.login_service.login_user()
-            headers = {"Authorization": "Bearer " + self.login_service.get_api_token(), }
+            headers = {"Authorization": "Bearer " + get_api_token(), }
             print("URL:", self.Thangs_Config.thangs_config['url'] + "api/models/parts/" + str(
                 self.model.partId) + "/download-url")
             try:
@@ -173,7 +173,7 @@ class ThangsApi:
                 elif response.status_code == 401 or response.status_code == 403:
                     try:
                         self.login_service.login_user()
-                        headers = {"Authorization": "Bearer " + self.login_service.get_api_token(), }
+                        headers = {"Authorization": "Bearer " + get_api_token(), }
                         response = requests.get(self.Thangs_Config.thangs_config['url']+"api/models/parts/"+str(self.model.partId)+"/download-url", headers=headers)
                         response.raise_for_status()
                     except Exception as ex:

--- a/thangs_importer.py
+++ b/thangs_importer.py
@@ -10,7 +10,7 @@ import time
 from config import get_config, get_api_token
 from api_clients import get_thangs_events
 from .model_importer import import_model
-from services import ThangsLoginService
+from services import ThangsLoginService, get_threading_service
 
 _thangs_api = None
 
@@ -152,7 +152,7 @@ class ThangsApi:
 
         if not fileExists:
             if not get_api_token():
-                self.login_service.login_user()
+                self.login_service.login_user(get_threading_service().wrap_up_threads)
             headers = {"Authorization": "Bearer " + get_api_token(), }
             print("URL:", self.Thangs_Config.thangs_config['url'] + "api/models/parts/" + str(
                 self.model.partId) + "/download-url")
@@ -172,7 +172,7 @@ class ThangsApi:
                     return
                 elif response.status_code == 401 or response.status_code == 403:
                     try:
-                        self.login_service.login_user()
+                        self.login_service.login_user(get_threading_service().wrap_up_threads)
                         headers = {"Authorization": "Bearer " + get_api_token(), }
                         response = requests.get(self.Thangs_Config.thangs_config['url']+"api/models/parts/"+str(self.model.partId)+"/download-url", headers=headers)
                         response.raise_for_status()


### PR DESCRIPTION
This ended up being a bit more complex than originally planned.

- [[Bug] : Switch to v3 search for Blender-Addon](https://github.com/physna/thangs-product-dev/issues/3472)
    - I found some geosearch bugs in the process of switching to v3 from v2 which are resolved now.
- [[Bug] : Wrap up threads in Blender Addon](https://github.com/physna/thangs-product-dev/issues/3473)
    - I made a global threading object that lets us know Blender is shutting down via the `unregister()` function. This seems to be a best practice for the addons. 
- [[Bug] : UserID on amplitude isn't filled out for Blender Addon events](https://github.com/physna/thangs-product-dev/issues/3474)
    - I was getting a circular reference error with trying to add the `ThangsLoginService` to the `ThangsEvents` object. The solution was to move this code to `ThangsConfig`. I don't love this solution but I think it's OK. The logic for the token setting and getting was moved there from `ThangsLoginService`. **Edit: we've since moved the code to it's own module instead of ThangsConfig.**